### PR TITLE
fix: XBlock tutorial on Internationalization link

### DIFF
--- a/sortable/translations/README.txt
+++ b/sortable/translations/README.txt
@@ -1,4 +1,4 @@
 Use this translations directory to provide internationalized strings for your XBlock project.
 
 For more information on how to enable translations, visit the Open edX XBlock tutorial on Internationalization:
-http://edx.readthedocs.org/projects/xblock-tutorial/en/latest/edx_platform/edx_lms.html
+https://docs.openedx.org/projects/xblock/en/latest/xblock-tutorial/edx_platform/edx_lms.html#internationalization-support


### PR DESCRIPTION
The previous link for XBlock tutorial on Internationalization was broken. This change replaces it with the correct one. 